### PR TITLE
Fix potential numerical instability in masked mean/std calculation

### DIFF
--- a/src/ffm/pytorch_patched_decoder_MOE.py
+++ b/src/ffm/pytorch_patched_decoder_MOE.py
@@ -103,26 +103,16 @@ def _masked_mean_std(
 
   # Calculate the number of valid elements
   num_valid_elements = torch.sum(mask, dim=1)
-  num_valid_elements = torch.where(
-      num_valid_elements == 0,
-      torch.tensor(1,
-                   dtype=num_valid_elements.dtype,
-                   device=num_valid_elements.device),
-      num_valid_elements,
-  )
+  num_valid_elements = torch.clamp(num_valid_elements, min=1.0)
 
-  # Calculate the masked sum and squared sum
+  # Calculate the masked sum and mean
   masked_sum = torch.sum(arr * mask, dim=1)
-  masked_squared_sum = torch.sum((arr * mask)**2, dim=1)
+  masked_mean = masked_sum / num_valid_elements  # [b]
 
-  # Calculate the masked mean and standard deviation
-  masked_mean = masked_sum / num_valid_elements
-  masked_var = masked_squared_sum / num_valid_elements - masked_mean**2
-  masked_var = torch.where(
-      masked_var < 0.0,
-      torch.tensor(0.0, dtype=masked_var.dtype, device=masked_var.device),
-      masked_var,
-  )
+  # Calculate the masked variance using centered values
+  masked_centered_arr = (arr - masked_mean.unsqueeze(-1)) * mask
+  masked_var = torch.sum(masked_centered_arr**2, dim=1) / num_valid_elements
+  masked_var = torch.clamp(masked_var, min=0.0)
   masked_std = torch.sqrt(masked_var)
 
   return masked_mean, masked_std
@@ -659,11 +649,7 @@ class PatchedTimeSeriesDecoder_MOE(nn.Module):
   ) -> tuple[torch.Tensor, tuple[torch.Tensor, torch.Tensor]]:
     """Input is of shape [B, N, P]."""
     mu, sigma = _masked_mean_std(inputs, patched_pads)
-    sigma = torch.where(
-        sigma < self.config.tolerance,
-        torch.tensor(1.0, dtype=sigma.dtype, device=sigma.device),
-        sigma,
-    )
+    sigma = torch.clamp(sigma, min=self.config.tolerance)
 
     # Normalize each patch
     outputs = (inputs - mu[:, None, None]) / sigma[:, None, None]


### PR DESCRIPTION
This PR fixes patch normalization issue in forward transform and incorrect clamping of calculated sigma to one instead of configured tolerance. Bug inherited from TimesFM codebase.

Issue affects contracts with relatively low absolute volatility, e.g. EURUSD and results in incorrect prediction.
See https://github.com/huggingface/transformers/pull/42099 for details.

@vincent05r This bug also affected pre-training run by altering loss for low-volatile symbols. It may make sense to run continued pre-training for some time to see if loss will reduce.